### PR TITLE
Kokkos emitter sparse

### DIFF
--- a/mlir/include/mlir/InitAllTranslations.h
+++ b/mlir/include/mlir/InitAllTranslations.h
@@ -19,6 +19,7 @@ namespace mlir {
 void registerFromLLVMIRTranslation();
 void registerFromSPIRVTranslation();
 void registerToCppTranslation();
+void registerToKokkosTranslation();
 void registerToLLVMIRTranslation();
 void registerToSPIRVTranslation();
 
@@ -30,6 +31,7 @@ inline void registerAllTranslations() {
     registerFromLLVMIRTranslation();
     registerFromSPIRVTranslation();
     registerToCppTranslation();
+    registerToKokkosTranslation();
     registerToLLVMIRTranslation();
     registerToSPIRVTranslation();
     return true;

--- a/mlir/lib/Pass/CMakeLists.txt
+++ b/mlir/lib/Pass/CMakeLists.txt
@@ -16,4 +16,5 @@ add_mlir_library(MLIRPass
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRIR
+  MLIRTargetKokkosCpp
   )

--- a/mlir/lib/Target/KokkosCpp/CMakeLists.txt
+++ b/mlir/lib/Target/KokkosCpp/CMakeLists.txt
@@ -6,11 +6,12 @@ add_mlir_translation_library(MLIRTargetKokkosCpp
   ${EMITC_MAIN_INCLUDE_DIR}/emitc/Target/KokkosCpp
 
   LINK_LIBS PUBLIC
+  MLIRIR
   MLIRArithDialect
   MLIRControlFlowDialect
   MLIREmitCDialect
   MLIRFuncDialect
-  MLIRIR
+  MLIRLLVMDialect
   MLIRMathDialect
   MLIRSCFDialect
   MLIRSupport

--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -1703,7 +1703,8 @@ LogicalResult KokkosCppEmitter::emitOperands(Operation &op) {
   auto emitOperandName = [&](Value result) -> LogicalResult {
     if (!hasValueInScope(result))
       return op.emitOpError() << "operand value not in scope";
-    os << getOrCreateName(result);
+    if(failed(emitValue(result)))
+      return failure();
     return success();
   };
   return interleaveCommaWithError(op.getOperands(), os, emitOperandName);


### PR DESCRIPTION
- Fix some build/link arising when doing a debug build
- Fix registration of ``--mlir-to-kokkos`` pass, so that ``mlir-translate`` utility can call it (this worked before upstream changes in December, then broke, now it works again)
- Kokkos emitter: support most of the required operations for sparse pytaco examples. The C++ for spmv.py seems to be emitted 100% correctly (minus the fact that the function is named ``main``, but that's not the emitter's fault). sparse_matadd.py is almost correct, but ``scf.while`` before/after block arguments aren't passed correctly, yet. Python/ctypes wrappers not working at all, need some work for passing sparse tensors in and out.

While sparse support in the emitter is a work-in-progress, this doesn't cause any regressions in what worked before (``matadd.py``) and I would like to stop this development from diverging so far from the main branch.