### PR TITLE
CPP driver infrastructure

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
@@ -129,6 +129,8 @@ class StridedMemrefIterator;
 /// StridedMemRef descriptor type with static rank.
 template <typename T, int N>
 struct StridedMemRefType {
+  using ValueType = T;
+  enum {Rank = N};
   T *basePtr;
   T *data;
   int64_t offset;
@@ -167,6 +169,8 @@ struct StridedMemRefType {
 /// StridedMemRef descriptor type specialized for rank 1.
 template <typename T>
 struct StridedMemRefType<T, 1> {
+  using ValueType = T;
+  enum {Rank = 1};
   T *basePtr;
   T *data;
   int64_t offset;
@@ -190,6 +194,8 @@ struct StridedMemRefType<T, 1> {
 /// StridedMemRef descriptor type specialized for rank 0.
 template <typename T>
 struct StridedMemRefType<T, 0> {
+  using ValueType = T;
+  enum {Rank = 0};
   T *basePtr;
   T *data;
   int64_t offset;

--- a/mlir/lib/ExecutionEngine/SparseTensorRuntime.cpp
+++ b/mlir/lib/ExecutionEngine/SparseTensorRuntime.cpp
@@ -325,6 +325,21 @@ extern "C" {
 static_assert(std::is_same<index_type, uint64_t>::value,
               "Expected index_type == uint64_t");
 
+}
+
+template<typename PrintAs, typename SMR>
+void printSMR(SMR smr)
+{
+  static_assert(SMR::Rank == 1);
+  for(size_t i = 0; i < smr.sizes[0]; i++)
+  {
+    std::cout << PrintAs(smr.data[i]) << ' ';
+  }
+  std::cout << "\n";
+}
+
+extern "C" {
+
 // TODO: this swiss-army-knife should be split up into separate functions
 // for each action, since the various actions don't agree on (1) whether
 // the first two arguments are "sizes" vs "shapes", (2) whether the "lvl"
@@ -337,6 +352,23 @@ void *_mlir_ciface_newSparseTensor( // NOLINT
     StridedMemRefType<index_type, 1> *lvl2dimRef,
     StridedMemRefType<index_type, 1> *dim2lvlRef, OverheadType ptrTp,
     OverheadType indTp, PrimaryType valTp, Action action, void *ptr) {
+  /*
+  std::cout << "Hello from _mlir_ciface_newSparseTensor!\n";
+  std::cout << "dimSizesRef: ";
+  printSMR<index_type>(*dimSizesRef);
+  std::cout << "lvlSizesRef: ";
+  printSMR<index_type>(*lvlSizesRef);
+  std::cout << "lvlTypesRef: ";
+  printSMR<int>(*lvlTypesRef);
+  std::cout << "lvl2dimRef: ";
+  printSMR<index_type>(*lvl2dimRef);
+  std::cout << "dim2lvlRef: ";
+  printSMR<index_type>(*dim2lvlRef);
+  std::cout << "indTp = " << (int) indTp << '\n';
+  std::cout << "valTp = " << (int) valTp << '\n';
+  std::cout << "action = " << (int) action << '\n';
+  std::cout << "ptr = " << ptr << '\n';
+  */
   ASSERT_NO_STRIDE(dimSizesRef);
   ASSERT_NO_STRIDE(lvlSizesRef);
   ASSERT_NO_STRIDE(lvlTypesRef);
@@ -637,6 +669,21 @@ void *_mlir_ciface_newSparseTensorFromReader(
     StridedMemRefType<index_type, 1> *lvl2dimRef,
     StridedMemRefType<index_type, 1> *dim2lvlRef, OverheadType ptrTp,
     OverheadType indTp, PrimaryType valTp) {
+  /*
+  std::cout << "Hello from _mlir_ciface_newSparseTensorFromReader!\n";
+  std::cout << "Reader (p): " << p << '\n';
+  std::cout << "lvlSizesRef: ";
+  printSMR<index_type>(*lvlSizesRef);
+  std::cout << "lvlTypesRef: ";
+  printSMR<int>(*lvlTypesRef);
+  std::cout << "lvl2dimRef: ";
+  printSMR<index_type>(*lvl2dimRef);
+  std::cout << "dim2lvlRef: ";
+  printSMR<index_type>(*dim2lvlRef);
+  std::cout << "ptrTp = " << (int) ptrTp << '\n';
+  std::cout << "indTp = " << (int) indTp << '\n';
+  std::cout << "valTp = " << (int) valTp << '\n';
+  */
   assert(p);
   SparseTensorReader &reader = *static_cast<SparseTensorReader *>(p);
   ASSERT_NO_STRIDE(lvlSizesRef);

--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -1698,7 +1698,10 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, func::FuncOp func
   {
     //Prevent support lib function names from being mangled
     if(isSupportFunc)
+    {
+      os << "#ifndef PYTACO_CPP_DRIVER\n";
       os << "extern \"C\" ";
+    }
     if(pointerResults)
     {
       os << "void ";
@@ -1745,6 +1748,8 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, func::FuncOp func
       return failure();
     }
     os << ");\n";
+    if(isSupportFunc)
+      os << "#endif\n";
     return success();
   }
   // Otherwise, it's a function definition with body.
@@ -1784,6 +1789,7 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, func::FuncOp func
     return failure();
   os << ") {\n";
   os.indent();
+  os << "std::cout << \"Hello from MLIR-Kokkos function " << functionOpName << "!\\n\";\n";
 
   //Convert any StridedMemRefType parameters to Kokkos::View
   for(BlockArgument arg : stridedMemrefParams)
@@ -1902,11 +1908,9 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, func::FuncOp func
   os.indent();
   //FOR DEBUGGING THE EMITTED CODE:
   //The next 3 lines makes the generated function pause to let you attach a debugger
-  /*
   os << "std::cout << \"Starting MLIR function on process \" << getpid() << '\\n';\n";
   os << "std::cout << \"Optionally attach debugger now, then press <Enter> to continue: \";\n";
   os << "std::cin.get();\n";
-  */
   //Create/allocate device Kokkos::Views for the memref inputs.
   //TODO: if executing on on host, we might as well use the NumPy buffers directly
   if(!emitter.supportingSparse())
@@ -3200,6 +3204,9 @@ static void emitCppBoilerplate(KokkosCppEmitter &emitter, bool enablePythonWrapp
   if(enableSparseSupport)
   {
     // This is the definition of the StridedMemRefType class, copied from mlir/include/mlir/ExecutionEngine/CRunnerUtils.h
+    emitter << "// If building a CPP driver, we can use the original StridedMemRefType class from MLIR,\n";
+    emitter << "// so do not redefine it here.\n";
+    emitter << "#ifndef PYTACO_CPP_DRIVER\n";
     emitter << "template <typename T, int N>\n";
     emitter << "struct StridedMemRefType {\n";
     emitter << "  T *basePtr;\n";
@@ -3207,7 +3214,25 @@ static void emitCppBoilerplate(KokkosCppEmitter &emitter, bool enablePythonWrapp
     emitter << "  int64_t offset;\n";
     emitter << "  int64_t sizes[N];\n";
     emitter << "  int64_t strides[N];\n";
-    emitter << "};\n\n";
+    emitter << "};\n";
+    emitter << "#endif\n";
+    emitter << "\n";
+    emitter << "// If building a CPP driver, need to provide a version of\n";
+    emitter << "//_mlir_ciface_newSparseTensor() that takes enum types, not underlying integer types.\n";
+    emitter << "#ifdef PYTACO_CPP_DRIVER\n";
+    emitter << "int8_t* _mlir_ciface_newSparseTensor(\n";
+    emitter << "  StridedMemRefType<index_type, 1> *dimSizesRef,\n";
+    emitter << "  StridedMemRefType<index_type, 1> *lvlSizesRef,\n";
+    emitter << "  StridedMemRefType<int8_t, 1> *lvlTypesRef,\n";
+    emitter << "  StridedMemRefType<index_type, 1> *lvl2dimRef,\n";
+    emitter << "  StridedMemRefType<index_type, 1> *dim2lvlRef, int ptrTp,\n";
+    emitter << "  int indTp, int valTp, int action, int8_t* ptr) {\n";
+    emitter << "    return (int8_t*) _mlir_ciface_newSparseTensor(dimSizesRef, lvlSizesRef,\n";
+    emitter << "      reinterpret_cast<StridedMemRefType<DimLevelType, 1>*>(lvlTypesRef),\n";
+    emitter << "      lvl2dimRef, dim2lvlRef, (OverheadType) ptrTp, (OverheadType) indTp,\n";
+    emitter << "      (PrimaryType) valTp, (Action) action, ptr);\n";
+    emitter << "  }\n";
+    emitter << "#endif\n\n";
 
     // Define utility functions to convert between Kokkos views and sparse tensor runtime objects.
     // This is View to StridedMemRefType. Supported for any input View type as long as it's in HostSpace.

--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -3220,7 +3220,8 @@ static void emitCppBoilerplate(KokkosCppEmitter &emitter, bool enablePythonWrapp
     emitter << "#endif\n";
     emitter << "\n";
     emitter << "// If building a CPP driver, need to provide a version of\n";
-    emitter << "//_mlir_ciface_newSparseTensor() that takes enum types, not underlying integer types.\n";
+    emitter << "// _mlir_ciface_newSparseTensor() that takes underlying integer types, not enum types like DimLevelType.\n";
+    emitter << "// The MLIR-Kokkos generated code doesn't know about the enum types at all.\n";
     emitter << "#ifdef PYTACO_CPP_DRIVER\n";
     emitter << "int8_t* _mlir_ciface_newSparseTensor(\n";
     emitter << "  StridedMemRefType<index_type, 1> *dimSizesRef,\n";

--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -1908,9 +1908,11 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, func::FuncOp func
   os.indent();
   //FOR DEBUGGING THE EMITTED CODE:
   //The next 3 lines makes the generated function pause to let you attach a debugger
+  /*
   os << "std::cout << \"Starting MLIR function on process \" << getpid() << '\\n';\n";
   os << "std::cout << \"Optionally attach debugger now, then press <Enter> to continue: \";\n";
   os << "std::cin.get();\n";
+  */
   //Create/allocate device Kokkos::Views for the memref inputs.
   //TODO: if executing on on host, we might as well use the NumPy buffers directly
   if(!emitter.supportingSparse())

--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -1789,7 +1789,6 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, func::FuncOp func
     return failure();
   os << ") {\n";
   os.indent();
-  os << "std::cout << \"Hello from MLIR-Kokkos function " << functionOpName << "!\\n\";\n";
 
   //Convert any StridedMemRefType parameters to Kokkos::View
   for(BlockArgument arg : stridedMemrefParams)


### PR DESCRIPTION
- Tweak emitter output to enable a standalone C++ driver (no python involved) to call the generated code
- Add some (commented out) debugging helpers inside the sparse runtime functions