### PR TITLE
[kokkos] add more dependent dialects

### DIFF
--- a/mlir/lib/Target/KokkosCpp/TranslateRegistration.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateRegistration.cpp
@@ -10,7 +10,9 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
@@ -39,7 +41,9 @@ void registerToKokkosTranslation() {
                         cf::ControlFlowDialect,
                         emitc::EmitCDialect,
                         func::FuncDialect,
+                        LLVM::LLVMDialect,
                         math::MathDialect,
+                        memref::MemRefDialect,
                         scf::SCFDialect>();
         // clang-format on
       });
@@ -57,6 +61,8 @@ void registerToKokkosTranslation() {
                         emitc::EmitCDialect,
                         func::FuncDialect,
                         math::MathDialect,
+                        LLVM::LLVMDialect,
+                        memref::MemRefDialect,
                         scf::SCFDialect>();
         // clang-format on
       });


### PR DESCRIPTION
When using mlir-translate command line, the translation fails with unregistered dialect "llvm" and "memref" when translating program lowered by sparse-compiler-kokkos.