### PR TITLE
🔨 explicitly link GPU dialect

### DIFF
--- a/mlir/lib/Target/KokkosCpp/CMakeLists.txt
+++ b/mlir/lib/Target/KokkosCpp/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_translation_library(MLIRTargetKokkosCpp
   MLIRControlFlowDialect
   MLIREmitCDialect
   MLIRFuncDialect
+  MLIRGPUDialect
   MLIRLLVMDialect
   MLIRMathDialect
   MLIRSCFDialect


### PR DESCRIPTION
The debug build otherwise, while building mlir-minimum-opt, errors out:
`mold: error: undefined symbol: mlir::gpu::MemcpyOp::getDstv`.
