### PR TITLE
🔧add pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/vmiheer/pre-commit-hooks.git
+  rev: 1504fb3144866f775c13f06acdd139150238ca57
+  hooks:
+    - id: clang-format-diff


### PR DESCRIPTION
For now it only enables, clang-format-diff. Some of existing code does
not follow LLVM coding convention. But we can use clang-format-diff to
enforce it for new changes.
