### PR TITLE
PartTensor: Don't use templated using-decls with CTAD

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/PartTensor/Storage.h
+++ b/mlir/include/mlir/ExecutionEngine/PartTensor/Storage.h
@@ -50,6 +50,9 @@ namespace mlir {
 // TODO: part_tensor need to have it's own namespace.
 namespace part_tensor {
 
+using llvm::ArrayRef;
+using std::unique_ptr;
+
 /**
  * Point in num-dims-dimensional-cartesian space.
  */
@@ -91,10 +94,6 @@ public:
 /// in a general manner.
 template <typename P = uint64_t, typename I = uint64_t, typename V = float>
 class PartTensorStorage : public PartTensorStorageBase {
-  template <typename T>
-  using ArrayRef = llvm::ArrayRef<T>;
-  template <typename T>
-  using unique_ptr = std::unique_ptr<T>;
 
 public:
   /// The called is resposible to keep spCOO alive for the lifetime of this


### PR DESCRIPTION
Fixes build errors with GCC (9.x?) from this line:
```
125       ArrayRef curPartSpec(partData.data() + loOffset, partSpecSize);
```
that would say "expected template arguments after ArrayRef"